### PR TITLE
Fix browser memory and TOCTOU security issues

### DIFF
--- a/core/settings.vala
+++ b/core/settings.vala
@@ -226,7 +226,12 @@ namespace Raphael {
                 // It's no error if the folder already exists
             }
             try {
-                keyfile.save_to_file (filename);
+                size_t length;
+                string contents = keyfile.to_data (out length);
+                uint8[] data = contents.data;
+                data.length = (int)length;
+                File.new_for_path (filename).replace_contents (data, null, false,
+                    FileCreateFlags.REPLACE_DESTINATION, null, null);
             } catch (Error error) {
                 critical ("Failed to save settings to %s: %s", filename, error.message);
             }

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -248,10 +248,10 @@ namespace Raphael {
                 string html = ((string)resources_lookup_data ("/data/error.html",
                                                              ResourceLookupFlags.NONE).get_data ())
                     .replace ("{stylesheet}", stylesheet)
-                    .replace ("{icon}", icon_name)
-                    .replace ("{title}", title)
-                    .replace ("{message}", message)
-                    .replace ("{description}", description ?? "")
+                    .replace ("{icon}", Markup.escape_text (icon_name))
+                    .replace ("{title}", Markup.escape_text (title))
+                    .replace ("{message}", Markup.escape_text (message))
+                    .replace ("{description}", Markup.escape_text (description ?? ""))
                     .replace ("{tryagain}", "<span>%s</span>".printf (_("Try Again")))
                     // HTML-escape the URI so it is safe as an HTML attribute value.
                     // error.html reads it back via getAttribute() which decodes entities.

--- a/extensions/adblock/subscription.vala
+++ b/extensions/adblock/subscription.vala
@@ -150,7 +150,7 @@ namespace Adblock {
             }
 
             // Skip if this hasn't been downloaded (yet)
-            if (!file.query_exists ()) {
+            if (!cache_file_is_regular ()) {
                 return false;
             }
 
@@ -158,9 +158,32 @@ namespace Adblock {
             return true;
         }
 
+        bool cache_file_is_regular () {
+            try {
+                var info = file.query_info ("standard::type,standard::is-symlink",
+                                            FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
+                return info.get_file_type () == FileType.REGULAR && !info.get_is_symlink ();
+            } catch (Error error) {
+                return false;
+            }
+        }
+
         bool ensure_downloaded (bool headers_only) {
-            if (file.query_exists ()) {
+            if (cache_file_is_regular ()) {
                 return true;
+            }
+
+            try {
+                file.query_info ("standard::type,standard::is-symlink",
+                                 FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
+                critical ("Refusing unsafe adblock cache path %s", file.get_path ());
+                return false;
+            } catch (Error error) {
+                if (!(error is IOError.NOT_FOUND)) {
+                    critical ("Failed to inspect adblock cache path %s: %s",
+                              file.get_path (), error.message);
+                    return false;
+                }
             }
 
             try {
@@ -170,7 +193,8 @@ namespace Adblock {
             }
 
             var download = WebKit.WebContext.get_default ().download_uri (uri.split ("&")[0]);
-            download.allow_overwrite = true;
+            // Do not allow a race to replace the destination with a symlink.
+            download.allow_overwrite = false;
             download.set_destination (file.get_uri ());
             download.finished.connect (() => {
                 queue_parse.begin (true);

--- a/extensions/web-extensions.vala
+++ b/extensions/web-extensions.vala
@@ -28,26 +28,53 @@ namespace WebExtension {
         }
 
         public void add_resource (string resource, Bytes data) {
+            if (!is_safe_resource_path (resource)) {
+                warning ("Ignoring unsafe extension resource path '%s'", resource);
+                return;
+            }
             if (_files == null) {
                 _files = new HashTable<string, Bytes> (str_hash, str_equal);
             }
             _files.insert (resource, data);
         }
 
+        internal static bool is_safe_resource_path (string resource) {
+            if (resource == "" || Path.is_absolute (resource)) {
+                return false;
+            }
+            foreach (string component in resource.replace ("\\", "/").split ("/")) {
+                if (component == ".." || component == "") {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public async Bytes get_resource (string resource) throws Error {
-            // Strip ./ or / prefix
-            string _resource = resource.has_prefix (".") ? resource.substring (1, -1) : resource;
-            _resource = _resource.has_prefix ("/") ? _resource.substring (1, -1) : _resource;
+            string _resource = resource;
+            while (_resource.has_prefix ("./")) {
+                _resource = _resource.substring (2, -1);
+            }
+            if (!is_safe_resource_path (_resource)) {
+                throw new FileError.PERM ("Unsafe resource path '%s'".printf (resource));
+            }
 
             if (_files != null && _files.contains (_resource)) {
                 return _files.lookup (_resource);
             }
             var child = file.get_child (_resource);
-            if (child.query_exists ()) {
+            try {
+                var info = child.query_info ("standard::type,standard::is-symlink",
+                                             FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
+                if (info.get_file_type () != FileType.REGULAR || info.get_is_symlink ()) {
+                    throw new FileError.PERM ("Resource is not a regular file");
+                }
                 uint8[] data;
                 if (yield child.load_contents_async (null, out data, null)) {
                     return new Bytes (data);
                 }
+            } catch (Error error) {
+                throw new FileError.IO ("Failed to open '%s': %s".printf (resource, error.message));
             }
             throw new FileError.IO ("Failed to open '%s': Not found in %s".printf (resource, name));
         }
@@ -128,17 +155,26 @@ namespace WebExtension {
                             if (archive.open_filename (file.get_path (), 10240) == Archive.Result.OK) {
                                 unowned Archive.Entry entry;
                                 while (archive.next_header (out entry) == Archive.Result.OK) {
+                                    if (!Extension.is_safe_resource_path (entry.pathname ())) {
+                                        warning ("Ignoring unsafe resource path in '%s'", file.get_path ());
+                                        continue;
+                                    }
                                     if (entry.pathname () == "manifest.json") {
                                         uint8[] buffer;
                                         int64 offset;
                                         archive.read_data_block (out buffer, out offset);
-                                        stream = new MemoryInputStream.from_data (buffer, free);
+                                        // libarchive owns this buffer. The binding
+                                        // returns a borrowed pointer, so the stream
+                                        // receives a copied array.
+                                        unowned uint8[] borrowed = buffer;
+                                        stream = new MemoryInputStream.from_data (borrowed, free);
                                     } else {
                                         uint8[] buffer;
                                         int64 offset;
                                         archive.read_data_block (out buffer, out offset);
                                         if (buffer.length > 0) {
-                                            extension.add_resource (entry.pathname (), new Bytes (buffer));
+                                            unowned uint8[] borrowed = buffer;
+                                            extension.add_resource (entry.pathname (), new Bytes (borrowed));
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary

- Fix ownership handling for libarchive archive buffers.
- Confine web-extension resources to their extension root and reject symlinks.
- Harden adblock cache handling against symlink/overwrite races.
- Atomically replace settings files.
- Escape network-derived error-page content before HTML insertion.

## Validation

- `cmake --build _build -j2` — passed.
- `ctest --test-dir _build --output-on-failure -R 'database|desktop|license|potfiles'` — 4 passed.
- Full ctest was attempted; `urlbar` could not start because no display was available and `xvfb-run` is not installed.

## Security context

These changes address memory ownership, path traversal, symlink/TOCTOU, atomic configuration writes, and internal error-page injection risks identified during the browser frontend security audit.

## Summary by Sourcery

Harden browser frontend against memory ownership issues, unsafe extension resource access, adblock cache races, non-atomic settings writes, and unescaped error-page content.

Bug Fixes:
- Restrict web-extension resources to safe, non-traversing, non-symlinked paths under the extension root.
- Ensure libarchive-backed extension data uses correctly owned buffers to avoid memory misuse.
- Require adblock subscription cache files to be regular non-symlink files and prevent overwrite races during downloads.
- Atomically replace settings files when saving configuration to avoid partial writes and race conditions.
- Escape error-page text content before inserting into HTML to prevent injection of network-derived data.