### PR TITLE
Fix stale permission request handling

### DIFF
--- a/core/tab.vala
+++ b/core/tab.vala
@@ -31,6 +31,7 @@ namespace Raphael {
         bool was_error = false;
         internal TlsCertificate? tls { get; protected set; default = null; }
         public string link_uri { get; protected set; }
+        WebKit.PermissionRequest? pending_permission = null;
 
         [GtkChild]
         internal unowned Gtk.Popover popover;
@@ -57,6 +58,21 @@ namespace Raphael {
                 // Undelay if needed
                 if (display_uri != uri) {
                     load_uri (display_uri);
+                }
+            });
+            confirm.clicked.connect (() => {
+                var permission = pending_permission;
+                pending_permission = null;
+                if (permission != null) {
+                    permission.allow ();
+                }
+                popover.hide ();
+            });
+            popover.closed.connect (() => {
+                var permission = pending_permission;
+                pending_permission = null;
+                if (permission != null) {
+                    permission.deny ();
                 }
             });
         }
@@ -385,24 +401,21 @@ namespace Raphael {
         }
 
         public override bool permission_request (WebKit.PermissionRequest permission) {
+            if (pending_permission != null) {
+                pending_permission.deny ();
+            }
+            pending_permission = permission;
             if (permission is WebKit.GeolocationPermissionRequest) {
                 string hostname = uri_hostname (uri);
                 message.label = _("%s wants to know your location.").printf (hostname);
             } else if (permission is WebKit.NotificationPermissionRequest) {
-                permission.allow ();
-                return true;
+                string hostname = uri_hostname (uri);
+                message.label = _("%s wants to show notifications.").printf (hostname);
             } else {
                 message.label = permission.get_type ().name ();
             }
             confirm.label = _("_Allow");
             confirm.show ();
-            confirm.clicked.connect (() => {
-                permission.allow ();
-                popover.hide ();
-            });
-            popover.closed.connect (() => {
-                permission.deny ();
-            });
             popover.show ();
             return true;
         }


### PR DESCRIPTION
## Summary

- Keep one pending permission request per tab.
- Connect permission approval and dismissal handlers once instead of once per request.
- Deny and replace any previous pending request when a new request arrives.
- Require explicit approval before allowing desktop notifications.

## Problem

Permission callbacks accumulated on the tab's confirmation button and popover. After multiple requests, one user action could invoke handlers for stale requests and make decisions for the wrong request.

## Validation

- `cmake --build _build -j2` — passed.
- `ctest --test-dir _build --output-on-failure -R 'database|desktop|license|potfiles'` — 4 passed.
- The GUI `urlbar` test remains unverified because no display or `xvfb-run` is available.

## Summary by Sourcery

Handle WebKit permission requests per tab with a single pending request and centralized confirmation/dismissal, ensuring explicit user approval for desktop notifications and preventing stale callbacks.

New Features:
- Require explicit user approval before granting desktop notification permissions from a tab.

Bug Fixes:
- Prevent stale permission callbacks from being invoked by reusing confirmation and dismissal handlers and replacing any previous pending request when a new one arrives.

Enhancements:
- Track a single pending WebKit permission request per tab and centralize its approval/denial logic on the tab-level popover and confirmation button.